### PR TITLE
Minor updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,3 +33,5 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 
 gem "webrick", "~> 1.8"
+
+gem "jekyll-redirect-from"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,7 @@ DEPENDENCIES
   github-pages (~> 231)
   http_parser.rb (~> 0.6.0)
   jekyll-feed (~> 0.12)
+  jekyll-redirect-from
   minima (~> 2.5)
   tzinfo (>= 1, < 3)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,7 @@ github_username:  mgds
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-redirect-from
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/eNewsletters/volume18/gma_vol1801.html
+++ b/eNewsletters/volume18/gma_vol1801.html
@@ -3,6 +3,7 @@ layout: newsletter
 date: '04.22.2025'
 volume: '18'
 number: '01'
+redirect_from: /eNewsletters/v3_7_5.html
 ---
 <p><br>Dear GeoMapApp community,<br></p>
 <p>We are pleased to announce a new release of GeoMapApp, version 3.7.5.</p>

--- a/index.markdown
+++ b/index.markdown
@@ -97,7 +97,7 @@ title="Tonga Trench Earthquakes" width="200" height="160">
     </li>
 </ul>		
 <br>
-<h3>Join our Mailing List</h3>
+<h3 id="subscribe">Join our Mailing List</h3>
 <p>
     The GeoMapApp mailing list provides users with information on releases and updates. 
     It's easy to subscribe, just  


### PR DESCRIPTION
- Added an id to the "Join our Mailing List" header so URLs can direct users right to it
- Added a redirect for the v3.7.5 eNewsletter (you can now to go /eNewsletters/v3_7_5.html and it'll redirect users to /eNewsletters/volume18/vol1801.html)